### PR TITLE
Implement zones for entities

### DIFF
--- a/game_rules/src/trigger/endturn.rs
+++ b/game_rules/src/trigger/endturn.rs
@@ -13,7 +13,7 @@ pub fn pre_end_turn_trigger<CTS>(
 where
     CTS: CTStack,
 {
-    let game_entity = x.entities.get(GAME_E_ID)?;
+    let game_entity = x.entities.get_entity(GAME_E_ID)?;
     let player_idx = game_entity
         .get_value(&EntityTags::CurrentPlayerOrd)
         .ok_or_else(|| format_err!("Missing CurrentPlayerOrd!"))?;
@@ -31,7 +31,7 @@ where
 {
     println!("[TURN_END_TRIGGER] PERI - END TURN");
     //
-    let game_entity = x.entities.get_mut(GAME_E_ID)?;
+    let game_entity = x.entities.get_entity_mut(GAME_E_ID)?;
     let mut game_proto = game_entity.as_proto_mut::<GameProto>()?;
     game_proto.set_next_player()?;
     //

--- a/game_rules/src/trigger/start.rs
+++ b/game_rules/src/trigger/start.rs
@@ -16,7 +16,7 @@ where
     //
     // Set the current turn to be for player 1 (1), the first player.
     // Note that the value for CurrentPlayerOrd is 1-indexed!
-    let game_entity = x.entities.get_mut(GAME_E_ID)?;
+    let game_entity = x.entities.get_entity_mut(GAME_E_ID)?;
     game_entity.set_value(EntityTags::CurrentPlayerOrd, 1);
     Ok(x)
 }

--- a/game_rules/tests/game_config_test.rs
+++ b/game_rules/tests/game_config_test.rs
@@ -35,14 +35,15 @@ fn config() {
     let machine = Machine::new(&config).unwrap();
     //
     assert_eq!(GAME_E_ID, 0);
-    let game_entity = machine.entities.get(GAME_E_ID).unwrap();
+    let game_entity = machine.entities.get_entity(GAME_E_ID).unwrap();
     let max_players = game_entity.get_value(&EntityTags::MaxPlayers).unwrap();
     assert_eq!(NUM_PLAYERS, max_players as usize);
     // Check the name for each player entity
     for i in 0..NUM_PLAYERS {
-        // Player id is 1-indexed
+        // Player id is 1-indexed, which matches perfectly on entity idx
+        // because the game entity ALWAYS has entity id 0.
         let player_idx = i + 1;
-        let player = machine.entities.get(player_idx).unwrap();
+        let player = machine.entities.get_entity(player_idx).unwrap();
         assert_eq!(player.human_readable, config.player_names[i]);
     }
 }

--- a/game_rules/tests/game_start_test.rs
+++ b/game_rules/tests/game_start_test.rs
@@ -22,7 +22,7 @@ fn game_setup() {
     let mut game = Machine::new(&config).expect("Error creating new game!");
 
     {
-        let game_entity = game.entities.get(GAME_E_ID).unwrap();
+        let game_entity = game.entities.get_entity(GAME_E_ID).unwrap();
         assert_eq!(GAME_E_ID, 0);
         assert_eq!(GAME_E_ID, game_entity.id());
     }
@@ -42,7 +42,7 @@ fn game_setup() {
     let first_turn = start_game(game).expect("Game unexpectedly finished");
 
     // Check we're currently within the turn of player 1.
-    let game_entity = first_turn.entities.get(GAME_E_ID).unwrap();
+    let game_entity = first_turn.entities.get_entity(GAME_E_ID).unwrap();
     assert_eq!(
         game_entity.get_value_default(&EntityTags::CurrentPlayerOrd),
         1
@@ -50,7 +50,7 @@ fn game_setup() {
     let second_turn = end_turn(first_turn).expect("Game unexpectedly finished");
 
     // Check we're currently within the turn of player 2.
-    let game_entity = second_turn.entities.get(GAME_E_ID).unwrap();
+    let game_entity = second_turn.entities.get_entity(GAME_E_ID).unwrap();
     assert_eq!(
         game_entity.get_value_default(&EntityTags::CurrentPlayerOrd),
         2

--- a/game_system/src/entity.rs
+++ b/game_system/src/entity.rs
@@ -3,10 +3,46 @@
 use medici_core::prefab::entity::EntityStruct;
 use prototype::ProtoItem;
 
+use medici_core::function::ZoneEnumerator;
 /// Unique ID value for the Game entity.
 pub use medici_core::prefab::entity::GAME_E_ID;
 /// The specialized entity structure for our state machine.
 pub type Entity = EntityStruct<EntityTags, ProtoItem>;
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+/// Enumeration of all conceptual positions an entity can be found at.
+///
+/// A zone is an abstraction of fysical locations within the context of a board game.
+/// When a player's pawn is on the board, it could be in the PLAY-zone. When a card
+/// is within a deck, it could be in the DECK-zone. Each player could have a HAND-zone.
+///
+/// Zones are isolated per player or shared for all players.
+pub enum Zones {
+    /// Isolated zone per player representing a void zone which can hold an 'unlimited'
+    /// amount of entities.
+    /// This zone has no function, entities just exist there.
+    Void,
+    /// Isolated zone per player representing it's deck (of card entities).
+    Deck,
+    /// Isolated zone per player representing it's hand (of card entities).
+    Hand,
+}
+
+impl ZoneEnumerator for Zones {
+    fn max_entities(&self) -> usize {
+        match *self {
+            Zones::Deck => 100,
+            Zones::Hand => 10,
+            _ => usize::max_value(),
+        }
+    }
+}
+
+impl Default for Zones {
+    fn default() -> Zones {
+        Zones::Void
+    }
+}
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 /// Enumeration of all entity property keys.

--- a/game_system/src/lib.rs
+++ b/game_system/src/lib.rs
@@ -66,12 +66,13 @@ pub mod prelude {
     // [`PushdownInto::pushdown`] and [`TransitionInto::transition`].
     pub use medici_core::ctstack::*;
     pub use medici_core::error::*;
-    pub use medici_core::function::{Card, CardBuilder, Entity, EntityBuilder, Service,
-                                    ServiceCompliance};
-    pub use medici_core::stm::checked::{PullupInto, PushdownInto, TransitionInto};
+    pub use medici_core::function::*;
+    pub use medici_core::stm::checked::*;
     pub use medici_core::transaction::{pack_transaction, unpack_transaction};
 
-    pub use entity::*;
+    // Importing everything from the entity submodule will also include the
+    // type [`entity::Entity`] which shadows the trait [`medici_core::function::Entity`].
+    pub use entity::{EntityTags, GAME_E_ID};
     pub use state_machine::config::SetupConfig;
     pub use state_machine::machine::Machine;
     pub use state_machine::state::leaf::triggerable::*;

--- a/game_system/src/state_machine/machine.rs
+++ b/game_system/src/state_machine/machine.rs
@@ -11,7 +11,7 @@ use medici_core::storage::{EntityStorage, StackStorage};
 use state_machine::state::prelude::*;
 use state_machine::transaction::TransactionItem;
 
-use entity::Entity;
+use entity::{Entity, Zones};
 
 /// The state machine.
 ///
@@ -49,7 +49,7 @@ where
     /// implemented.
     pub transactions: StackStorage<TransactionItem>,
     /// Entities handler.
-    pub entities: EntityStorage<Entity>,
+    pub entities: EntityStorage<Entity, Zones>,
     /// Trigger handler.
     pub triggers: TriggerService<TimingItem, TriggerItem>,
 }
@@ -93,16 +93,16 @@ where
     }
 }
 
-impl<X, CTS> ServiceCompliance<EntityStorage<Entity>> for Machine<X, CTS>
+impl<X, CTS> ServiceCompliance<EntityStorage<Entity, Zones>> for Machine<X, CTS>
 where
     X: marker::TopLevel + State,
     CTS: CTStack,
 {
-    fn get(&self) -> &EntityStorage<Entity> {
+    fn get(&self) -> &EntityStorage<Entity, Zones> {
         &self.entities
     }
 
-    fn get_mut(&mut self) -> &mut EntityStorage<Entity> {
+    fn get_mut(&mut self) -> &mut EntityStorage<Entity, Zones> {
         &mut self.entities
     }
 }

--- a/medici_core/Cargo.toml
+++ b/medici_core/Cargo.toml
@@ -11,6 +11,13 @@ value_from_type_traits = "1.0.2"
 failure = "0.1.1"
 failure_derive = "0.1.1"
 maplit = "1.0.1"
+indexmap = "1.0.1"
+
+[dependencies.rand]
+# Rand is currently going through an update which breaks backwards compatibility.
+# Be aware that updating this dependancy will break the build!
+version = "0.4.2"
+features = ["nightly"]
 
 # [patch.crates-io]
 # value_from_type_macros = { path = "D:\\Git\\value-from-type-derive\\value_from_type_macros" }

--- a/medici_core/src/ctstack.rs
+++ b/medici_core/src/ctstack.rs
@@ -14,7 +14,7 @@ pub type ZeroSizedType<T> = PhantomData<T>;
 /// Type for starting a new CTStack.
 pub type EmptyStack = ();
 /// Type representing aq CTStack with any contents.
-/// 
+///
 /// # Safety
 /// This is valid if all CTStack types are zero-sized!
 /// Do NOT use this type otherwise.

--- a/medici_core/src/function.rs
+++ b/medici_core/src/function.rs
@@ -1,7 +1,10 @@
 //! Contains the core functionality items for our system.
+use std::fmt::{Debug, Display};
 
 use ctstack::CTStack;
+use failure::Error;
 use marker;
+use service::error::{MissingEntityError, OverflowError};
 
 /// Trait generalizing over any structure that could act as a container of states.
 ///
@@ -49,6 +52,21 @@ pub trait Service {
     // Note; It's quite possible this trait will receive methods later on.
 }
 
+/// Trait for implementing a certain service on the state machine.
+///
+/// Because of this design exactly one object of each service type can be hooked onto
+/// the same state machine.
+pub trait ServiceCompliance<S>
+where
+    S: Service,
+    Self: StateContainer,
+{
+    /// Retrieves an immutable reference to service `S`.
+    fn get(&self) -> &S;
+    /// Retrieves a mutable reference to service `S`.
+    fn get_mut(&mut self) -> &mut S;
+}
+
 /// Type that's generally used to identify and order [`Entity`] objects.
 ///
 /// Throughout medici-core it's assumed this type is an alias for a numeric
@@ -71,7 +89,7 @@ pub trait Entity {
 /// Trait used to create a new [`Entity`] object.
 pub trait EntityBuilder<E: Entity> {
     /// Build a new [`Entity`] with the provided identifier.
-    fn new_with_id(id: E::ID) -> E;
+    fn new_with_id<X: Into<E::ID>>(id: X) -> Result<E, Error>;
 }
 
 /// Type thet's generally used to identify and order [`Card`] objects.
@@ -109,17 +127,8 @@ pub trait Card {
 /// Trait used to create a new [`Card`] object.
 pub trait CardBuilder<C: Card> {}
 
-/// Trait for implementing a certain service on the state machine.
-///
-/// Because of this design exactly one object of each service type can be hooked onto
-/// the same state machine.
-pub trait ServiceCompliance<S>
-where
-    S: Service,
-    Self: StateContainer,
-{
-    /// Retrieves an immutable reference to service `S`.
-    fn get(&self) -> &S;
-    /// Retrieves a mutable reference to service `S`.
-    fn get_mut(&mut self) -> &mut S;
+/// Types which enumerate all possible zones in the game.
+pub trait ZoneEnumerator {
+    /// Returns the amount of entities this zone can hold.
+    fn max_entities(&self) -> usize;
 }

--- a/medici_core/src/lib.rs
+++ b/medici_core/src/lib.rs
@@ -27,8 +27,9 @@ pub extern crate value_from_type_traits;
 
 pub extern crate failure;
 extern crate failure_derive;
-#[macro_use]
+extern crate indexmap;
 extern crate maplit;
+extern crate rand;
 
 mod workaround;
 

--- a/medici_core/src/prefab/entity.rs
+++ b/medici_core/src/prefab/entity.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use failure::Error;
+use maplit::{hashmap, hashset};
 use value_from_type_traits::IntoEnum;
 
 use function::{self, EntityBuilder, EntityId};

--- a/medici_core/src/prefab/entity.rs
+++ b/medici_core/src/prefab/entity.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::hash::Hash;
 
+use failure::Error;
 use value_from_type_traits::IntoEnum;
 
 use function::{self, EntityBuilder, EntityId};
@@ -63,13 +64,13 @@ where
     S: Clone + Eq + Hash,
     P: marker::ProtoEnumerator + Clone + Eq + Hash,
 {
-    fn new_with_id(id: EntityId) -> Self {
-        Self {
-            id,
+    fn new_with_id<X: Into<EntityId>>(id: X) -> Result<Self, Error> {
+        Ok(Self {
+            id: id.into(),
             state: hashmap!{},
             prototypes: hashset!{},
             human_readable: None,
-        }
+        })
     }
 }
 

--- a/medici_core/src/service/mod.rs
+++ b/medici_core/src/service/mod.rs
@@ -1,8 +1,10 @@
 //! Types that provide functionality to your application.
-//! These types can be added AD-HOC to your (state) machine
-//! declaration.
-//! Other components of this framework also need some of these
-//! services to be implemented before use.
+//! These types are designed to be inserted ad-hoc into your state
+//! machine structures.
+//!
+//! Prefab components of this framework will need some of the
+//! services being accessible through the built state machine.
 
 pub mod error;
 pub mod trigger;
+pub mod zone;

--- a/medici_core/src/service/zone.rs
+++ b/medici_core/src/service/zone.rs
@@ -1,0 +1,19 @@
+//! Module containing structures for working with zones.
+//!
+//! Zones are groups of entities. Each entity can only occur
+//! in ONE zone at a time.
+
+/*
+#[derive(Debug)]
+struct Zone<'a, E, I, EZ>
+where
+    E: Entity + 'a,
+    <E as Entity>::ID: Display + Debug,
+    I: Iterator<Item = &'a E>,
+    EZ: ZoneEnumerator + Default,
+{
+    kind: EZ,
+    limit: usize,
+    entities: I,
+}
+*/

--- a/medici_core/src/storage/card.rs
+++ b/medici_core/src/storage/card.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 
+use maplit::hashmap;
+
 use function::{Card, Service};
 use marker;
 use storage::UnsafeTrigger;

--- a/medici_core/src/storage/mod.rs
+++ b/medici_core/src/storage/mod.rs
@@ -4,8 +4,10 @@ mod card;
 mod entity;
 mod stack;
 mod trigger;
+mod zone;
 
 pub use self::card::*;
 pub use self::entity::*;
 pub use self::stack::*;
 pub use self::trigger::*;
+pub use self::zone::*;

--- a/medici_core/src/storage/zone.rs
+++ b/medici_core/src/storage/zone.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use failure::Error;
+use indexmap::set::IndexSet;
+use maplit::hashmap;
+
+use function::{Entity, ZoneEnumerator};
+
+#[derive(Debug, Clone)]
+/// Structure for assigning zones to entities.
+pub struct ZoneEntityStorage<E, EZ>
+where
+    E: Entity,
+    <E as Entity>::ID: Copy + Debug + PartialEq + Eq + Hash,
+    EZ: ZoneEnumerator + Default + Clone + Debug + PartialEq + Eq + Hash,
+{
+    zone_assignment: HashMap<EZ, IndexSet<E::ID>>,
+}
+
+impl<E, EZ> ZoneEntityStorage<E, EZ>
+where
+    E: Entity,
+    <E as Entity>::ID: Copy + Debug + PartialEq + Eq + Hash,
+    EZ: ZoneEnumerator + Default + Clone + Debug + PartialEq + Eq + Hash,
+{
+    /// Creates a new storage object which keeps track of entities located/moving
+    /// between zones.
+    pub fn new() -> Self {
+        Self {
+            zone_assignment: hashmap!{},
+        }
+    }
+
+    /*
+     * Note: Zone operations require both the container AND the entity to be mutable!
+     * Having both mutable means we can't introduce unintuitive results because of the
+     * loose coupling between zones and entities.
+     */
+
+    /// Event for a newly created entity.
+    ///
+    /// This method will insert a new zone-entry for the provided [`Entity`].
+    pub(crate) fn new_entity(&mut self, _entity: &mut E) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    /// Moves the provided entity into the given zone.
+    pub fn move_zone(&mut self, _entity: &mut E, _zone: EZ) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    /// Moves the provided entity to the provided position within it's current zone.
+    ///
+    /// TODO; Figure out how to quickly retrieve this zone, either;
+    ///     * Implement hidden properties for [`Entity`] and use them only within core.
+    ///     * Implement a two-way mapping between entities and zones.
+    pub fn move_position(&mut self, _entity: &mut E, _position: usize) -> Result<(), Error> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
My intention is to assign an additional property to entities called zones.
A zone is a conceptual location where an entity can be 'found'. Each entity can only belong to EXACTLY ONE zone, but can be moved into another zone if need be.
A zone also has the concept of positioning, so there is a first, second, third .. entity for a given snapshot of a zone.
It's up to implementers to decide of this zone concept applies isolated per player (each player has his own set of zones) or shared by all players (one set of zones) or mixed.

Zones are deemed core so it's directly contained by core::storage::EntityStorage, while still being written into its own file because it's conceptually a storage component. The concept is not introduced into core::prefab::EntityStruct because zone-handling is something that must be provided to the implementer, not implement himself.

Ideally i would like to make the zone storage type toggle-able through generics or build-features, but no elegant solution has come to mind yet. I do lean more towards build-features currently.

More updates are inbound..