### PR TITLE
Introduced Identifiable trait + updates to storagecompliance

### DIFF
--- a/game_system/src/lib.rs
+++ b/game_system/src/lib.rs
@@ -3,7 +3,10 @@
 // Prevent successful compilation when documentation is missing.
 #![deny(missing_docs)]
 // Unstable features.
-#![feature(associated_type_defaults, try_from, never_type, proc_macro, proc_macro_mod, proc_macro_path_invoc, nll)]
+#![feature(
+    associated_type_defaults, try_from, never_type, proc_macro, proc_macro_mod,
+    proc_macro_path_invoc, nll
+)]
 // Clippy linting when building debug versions.
 //#![cfg_attr(test, feature(plugin))]
 //#![cfg_attr(test, plugin(clippy))]
@@ -65,9 +68,9 @@ pub mod prelude {
     // [`PushdownInto::pushdown`] and [`TransitionInto::transition`].
     pub use medici_core::ctstack::*;
     pub use medici_core::error::{self, ErrorKind, FrontendErrorExt, HydratedErrorExt, MachineError};
-    pub use medici_core::function::{Card, CardBuilder, Entity, EntityBuilder,
-                                    IndexedStorageCompliance, ServiceCompliance,
-                                    StackStorageCompliance};
+    pub use medici_core::function::{ArrayStorageCompliance, Card, CardBuilder, Entity,
+                                    EntityBuilder, Identifiable, IndexedStorageCompliance,
+                                    ServiceCompliance, StackStorageCompliance};
     // Macros
     pub use medici_core::stm::checked::{PullupInto, PushdownInto, TransitionInto};
     pub use medici_core::transaction::{pack_transaction, unpack_transaction};

--- a/medici_core/src/lib.rs
+++ b/medici_core/src/lib.rs
@@ -2,7 +2,10 @@
 #![allow(unused_unsafe)]
 #![deny(missing_docs)]
 // Unstable features.
-#![feature(associated_type_defaults, try_from, never_type, proc_macro, proc_macro_mod, proc_macro_path_invoc)]
+#![feature(
+    associated_type_defaults, try_from, never_type, proc_macro, proc_macro_mod,
+    proc_macro_path_invoc
+)]
 // Clippy linting when building debug versions.
 // #![cfg_attr(test, feature(plugin))]
 // #![cfg_attr(test, plugin(clippy))]

--- a/medici_core/src/prefab/card.rs
+++ b/medici_core/src/prefab/card.rs
@@ -23,15 +23,21 @@ where
     pub properties: HashMap<S, u32>,
 }
 
+impl<S> function::Identifiable for CardStruct<S>
+where
+    S: Clone + Eq + Hash,
+{
+    type ID = CardId;
+
+    fn id(&self) -> CardId {
+        self.uid
+    }
+}
+
 impl<S> function::Card for CardStruct<S>
 where
     S: Clone + Eq + Hash,
 {
-    type UID = CardId;
     type TimingEnum = TimingItem;
     type TriggerEnum = TriggerItem;
-
-    fn uid(&self) -> CardId {
-        self.uid
-    }
 }

--- a/medici_core/src/prefab/entity.rs
+++ b/medici_core/src/prefab/entity.rs
@@ -46,7 +46,7 @@ where
     pub human_readable: Option<String>,
 }
 
-impl<S, P> function::Entity for EntityStruct<S, P>
+impl<S, P> function::Identifiable for EntityStruct<S, P>
 where
     S: Clone + Eq + Hash,
     P: marker::ProtoEnumerator + Clone + Eq + Hash,
@@ -56,6 +56,13 @@ where
     fn id(&self) -> Self::ID {
         self.id
     }
+}
+
+impl<S, P> function::Entity for EntityStruct<S, P>
+where
+    S: Clone + Eq + Hash,
+    P: marker::ProtoEnumerator + Clone + Eq + Hash,
+{
 }
 
 impl<S, P> EntityBuilder<Self> for EntityStruct<S, P>

--- a/medici_core/src/service/entity.rs
+++ b/medici_core/src/service/entity.rs
@@ -3,7 +3,7 @@
 use std::fmt::{Debug, Display};
 
 use error::custom_type::{MissingEntityError, OverflowError};
-use function::{Entity, EntityBuilder, IndexedStorageCompliance};
+use function::{ArrayStorageCompliance, Entity, EntityBuilder};
 use marker;
 use storage::EntityStorage;
 

--- a/medici_core/src/storage/card.rs
+++ b/medici_core/src/storage/card.rs
@@ -4,12 +4,16 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 
-use function::Card;
+use function::{Card, Identifiable, IndexedStorageCompliance};
 use marker;
 use storage::trigger::UnsafeTrigger;
 
 #[derive(Debug, Clone)]
-/// Structure serializing/deserializing a game card.
+/// Wrapper for a GameCard.
+///
+/// This wrapper is unsafe because working with the triggers it contain
+/// is unsafe. The actual type of the state machine has been erased.
+/// See [`UnsafeTrigger`].
 pub struct UnsafeCardEntry<C>
 where
     C: Card,
@@ -20,23 +24,54 @@ where
     triggers: Vec<UnsafeTrigger<C::TimingEnum, C::TriggerEnum>>,
 }
 
+impl<C> Identifiable for UnsafeCardEntry<C>
+where
+    C: Card,
+    C::TimingEnum: marker::TimingEnumerator + Copy,
+    C::TriggerEnum: marker::TriggerEnumerator + Copy,
+{
+    type ID = <C as Identifiable>::ID;
+
+    fn id(&self) -> Self::ID {
+        self.card.id()
+    }
+}
+
 #[derive(Debug, Clone)]
 /// Structure holding onto all cards defined for a specific machine.
 pub struct CardStorage<C>
 where
     C: Card,
-    C::UID: Copy + Eq + Hash,
+    <C as Identifiable>::ID: Debug + Copy + Eq + Hash,
     C::TimingEnum: marker::TimingEnumerator + Debug + Copy,
     C::TriggerEnum: marker::TriggerEnumerator + Debug + Copy,
 {
     /// Contains unsafe versions of implemented cards.
-    pub cards: HashMap<C::UID, UnsafeCardEntry<C>>,
+    pub cards: HashMap<<C as Identifiable>::ID, UnsafeCardEntry<C>>,
+}
+
+impl<C> IndexedStorageCompliance for CardStorage<C>
+where
+    C: Card,
+    <C as Identifiable>::ID: Debug + Copy + Eq + Hash,
+    C::TimingEnum: marker::TimingEnumerator + Debug + Copy,
+    C::TriggerEnum: marker::TriggerEnumerator + Debug + Copy,
+{
+    type Item = UnsafeCardEntry<C>;
+
+    fn get(&self, identifier: <Self::Item as Identifiable>::ID) -> Option<&Self::Item> {
+        self.cards.get(&identifier)
+    }
+
+    fn get_mut(&mut self, identifier: <Self::Item as Identifiable>::ID) -> Option<&mut Self::Item> {
+        self.cards.get_mut(&identifier)
+    }
 }
 
 impl<C> CardStorage<C>
 where
     C: Card,
-    C::UID: Copy + Eq + Hash,
+    <C as Identifiable>::ID: Debug + Copy + Eq + Hash,
     C::TimingEnum: marker::TimingEnumerator + Debug + Copy,
     C::TriggerEnum: marker::TriggerEnumerator + Debug + Copy,
 {

--- a/medici_core/src/storage/entity.rs
+++ b/medici_core/src/storage/entity.rs
@@ -1,6 +1,6 @@
 //! Module containing structures for storing entities.
 
-use function::{Entity, IndexedStorageCompliance};
+use function::{ArrayStorageCompliance, Entity};
 
 #[derive(Debug, Clone)]
 /// Structure wrapping a [`Vec`] to provide a container for (all) entities
@@ -29,7 +29,7 @@ where
     }
 }
 
-impl<E> IndexedStorageCompliance for EntityStorage<E>
+impl<E> ArrayStorageCompliance for EntityStorage<E>
 where
     E: Entity + Clone,
     E::ID: Into<usize> + From<usize>,


### PR DESCRIPTION
The Identifiable trait can be used to enforce an identifier being present on game objects.

StorageCompliance traits have been updated to make use of the new Identifiable trait.
There is also a new trait, ArrayStorageCompliance which takes over the previous behaviour of IndexedStorageCompliance. IndexedStorage now serves as an API for querying game objects by their identifier. `std::ops::Index` could not be used for this behaviour because it's designed to panic when querying an unknown index value (identifier).