### PR TITLE
Implement Adapters

### DIFF
--- a/game_system/src/lib.rs
+++ b/game_system/src/lib.rs
@@ -43,6 +43,7 @@ pub mod runtime;
 pub mod setup;
 pub mod state_machine;
 pub mod tag;
+pub mod zone;
 
 /// Exported types from [`medici_core`].
 ///

--- a/game_system/src/lib.rs
+++ b/game_system/src/lib.rs
@@ -72,11 +72,14 @@ pub mod prelude {
     // These traits must be in scope to properly use [`PullupInto::pullup`],
     // [`PushdownInto::pushdown`] and [`TransitionInto::transition`].
     pub use medici_core::ctstack::*;
-    pub use medici_core::error::{self, ErrorKind, FrontendErrorExt, HydratedErrorExt, MachineError};
-    pub use medici_core::function::{self, ArrayStorageCompliance, Card as CardTrait, CardBuilder,
-                                    CardId, Entity as EntityTrait, EntityBuilder, EntityId,
-                                    Identifiable, IndexedStorageCompliance, ServiceCompliance,
-                                    StackStorageCompliance};
+    pub use medici_core::error::{
+        self, ErrorKind, FrontendErrorExt, HydratedErrorExt, MachineError,
+    };
+    pub use medici_core::function::{
+        self, ArrayStorageCompliance, Card as CardTrait, CardBuilder, CardId,
+        Entity as EntityTrait, EntityBuilder, EntityId, Identifiable, IndexedStorageCompliance,
+        ServiceCompliance, StackStorageCompliance,
+    };
     pub use medici_core::stm::checked::{PullupInto, PushdownInto, TransitionInto};
     pub use medici_core::transaction::{pack_transaction, unpack_transaction};
 

--- a/game_system/src/state_machine/machine.rs
+++ b/game_system/src/state_machine/machine.rs
@@ -10,6 +10,7 @@ use medici_core::storage::TransactionStorage;
 
 use state_machine::state::prelude::*;
 use state_machine::transaction::TransactionItem;
+use zone::ZoneItem;
 
 use entity::Entity;
 
@@ -52,6 +53,10 @@ where
     /// Storage object allowing [`PushdownInto`] and [`PullupInto`] to store
     /// the [`Transaction`] objects for each state to be re-used.
     pub transactions: TransactionStorage<TransactionItem>,
+    // Stub services, these are inaccessable because they only contain owned
+    // data. No functionality is defined on them.
+    // Build the service to manipulate its data.
+    pub(crate) stub_zone: ZoneServiceStub<Entity, ZoneItem>,
 }
 
 impl<X, CTS> StateContainer for Machine<X, CTS>

--- a/game_system/src/state_machine/state/toplevel.rs
+++ b/game_system/src/state_machine/state/toplevel.rs
@@ -4,5 +4,6 @@
 //! for any given state of the state machine.
 
 /// Export the prefab toplevel states.
-pub use medici_core::prefab::state::{Action, DeathEffect, Effect, Finished, RecurseEffect,
-                                     Trigger, Wait};
+pub use medici_core::prefab::state::{
+    Action, DeathEffect, Effect, Finished, RecurseEffect, Trigger, Wait,
+};

--- a/game_system/src/zone.rs
+++ b/game_system/src/zone.rs
@@ -1,0 +1,25 @@
+//! Module containing zone definitions.
+
+use medici_core::function::ZoneEnumerator;
+
+#[derive(Debug)]
+pub enum ZoneItem {
+    SetAside,
+    Deck,
+    Play,
+    Hand,
+    // Chance,
+    // Car,
+    // FreePark,
+}
+
+impl ZoneEnumerator for ZoneItem {
+    fn max_entities(&self) -> usize {
+    	match *self {
+    	    ZoneItem::SetAside => usize::MAX,
+    	    ZoneItem::Deck => 30,
+    	    ZoneItem::Play => 7,
+    	    ZoneItem::Hand => 10,
+    	}
+    }
+}

--- a/game_system/src/zone.rs
+++ b/game_system/src/zone.rs
@@ -15,11 +15,11 @@ pub enum ZoneItem {
 
 impl ZoneEnumerator for ZoneItem {
     fn max_entities(&self) -> usize {
-    	match *self {
-    	    ZoneItem::SetAside => usize::MAX,
-    	    ZoneItem::Deck => 30,
-    	    ZoneItem::Play => 7,
-    	    ZoneItem::Hand => 10,
-    	}
+        match *self {
+            ZoneItem::SetAside => usize::MAX,
+            ZoneItem::Deck => 30,
+            ZoneItem::Play => 7,
+            ZoneItem::Hand => 10,
+        }
     }
 }

--- a/medici_core/src/ctmut.rs
+++ b/medici_core/src/ctmut.rs
@@ -4,13 +4,13 @@
 use std::convert::{AsMut, AsRef};
 
 /// Compile time boolean.
-/// 
+///
 /// Types implementing this trait are used to enforce certain behaviour.
-/// 
+///
 /// # See also
 /// [`MutSwitch`]
 pub trait CTBool {
-    /// Runtime value for 
+    /// Runtime value for
     const VALUE: bool;
 }
 
@@ -73,7 +73,7 @@ impl<'a, T: 'a> MutSwitch<'a, T, CTTrue> {
     }
 
     /// Returns the mutable reference stored within.
-    pub fn get(&mut self) -> &mut T {
+    pub fn get_mut(&mut self) -> &mut T {
         match *self {
             MutSwitch::VarMut(ref mut v, _) => v,
             _ => unreachable!(),
@@ -89,7 +89,7 @@ impl<'a, T: 'a> AsRef<T> for MutSwitch<'a, T, CTFalse> {
 
 impl<'a, T: 'a> AsMut<T> for MutSwitch<'a, T, CTTrue> {
     fn as_mut(&mut self) -> &mut T {
-        self.get()
+        self.get_mut()
     }
 }
 

--- a/medici_core/src/ctmut.rs
+++ b/medici_core/src/ctmut.rs
@@ -35,10 +35,9 @@ impl CTBool for CTFalse {
 /// The intention is to have this enumeration abstract over mutable or immutable
 /// access so code doesn't need to be duplicated to create a mutable container
 /// for each immutable container.
-pub enum MutSwitch<'a, T, AllowMut>
+pub enum MutSwitch<'a, T: 'a, AllowMut>
 where
     AllowMut: CTBool,
-    T: 'a,
 {
     /// An immutable reference is stored.
     VarImut(&'a T),
@@ -51,7 +50,7 @@ where
 }
 
 // Implement immutable functionality.
-impl<'a, T> MutSwitch<'a, T, CTFalse> {
+impl<'a, T: 'a> MutSwitch<'a, T, CTFalse> {
     /// Constructs this enum with an immutable reference.
     pub fn from_ref(t: &'a T) -> Self {
         MutSwitch::VarImut(t)
@@ -67,7 +66,7 @@ impl<'a, T> MutSwitch<'a, T, CTFalse> {
 }
 
 // Implement mutable functionality.
-impl<'a, T> MutSwitch<'a, T, CTTrue> {
+impl<'a, T: 'a> MutSwitch<'a, T, CTTrue> {
     /// Constructs this enum with a mutable reference.
     pub fn from_mut(t: &'a mut T) -> Self {
         MutSwitch::VarMut(t, CTTrue)
@@ -82,25 +81,25 @@ impl<'a, T> MutSwitch<'a, T, CTTrue> {
     }
 }
 
-impl<'a, T> AsRef<T> for MutSwitch<'a, T, CTFalse> {
+impl<'a, T: 'a> AsRef<T> for MutSwitch<'a, T, CTFalse> {
     fn as_ref(&self) -> &T {
         self.get()
     }
 }
 
-impl<'a, T> AsMut<T> for MutSwitch<'a, T, CTTrue> {
+impl<'a, T: 'a> AsMut<T> for MutSwitch<'a, T, CTTrue> {
     fn as_mut(&mut self) -> &mut T {
         self.get()
     }
 }
 
-impl<'a, T> From<&'a T> for MutSwitch<'a, T, CTFalse> {
+impl<'a, T: 'a> From<&'a T> for MutSwitch<'a, T, CTFalse> {
     fn from(t: &'a T) -> Self {
         MutSwitch::from_ref(t)
     }
 }
 
-impl<'a, T> From<&'a mut T> for MutSwitch<'a, T, CTTrue> {
+impl<'a, T: 'a> From<&'a mut T> for MutSwitch<'a, T, CTTrue> {
     fn from(t: &'a mut T) -> Self {
         MutSwitch::from_mut(t)
     }

--- a/medici_core/src/ctmut.rs
+++ b/medici_core/src/ctmut.rs
@@ -1,0 +1,107 @@
+//! Module which implements an enum to handle the difference between
+//! utilizing a mutable and immutable reference to something.
+
+use std::convert::{AsMut, AsRef};
+
+/// Compile time boolean.
+/// 
+/// Types implementing this trait are used to enforce certain behaviour.
+/// 
+/// # See also
+/// [`MutSwitch`]
+pub trait CTBool {
+    /// Runtime value for 
+    const VALUE: bool;
+}
+
+/// Type used to enforce a True value during compilation.
+pub struct CTTrue;
+impl CTBool for CTTrue {
+    const VALUE: bool = true;
+}
+
+/// Type used to enforce a False value during compilation.
+// Equivalent to never-type (!), but the [`Lock`] concept cannot be applied
+// when ! is used.
+pub type CTFalse = !;
+impl CTBool for CTFalse {
+    const VALUE: bool = false;
+}
+
+#[derive(Debug)]
+/// Enumeration for simplifying access to a certain object.
+///
+/// This enumeration can hold a mutable or immutable reference to an object.
+/// The intention is to have this enumeration abstract over mutable or immutable
+/// access so code doesn't need to be duplicated to create a mutable container
+/// for each immutable container.
+pub enum MutSwitch<'a, T, AllowMut>
+where
+    AllowMut: CTBool,
+    T: 'a,
+{
+    /// An immutable reference is stored.
+    VarImut(&'a T),
+    /// A mutable reference is stored.
+    ///
+    /// AllowMut is used to prevent this variant from being constructed when it's a
+    /// "void type". This results in an sound logic where a mutable reference can never
+    /// be created from an immutable reference + acts as compiler optimization hint.
+    VarMut(&'a mut T, AllowMut),
+}
+
+// Implement immutable functionality.
+impl<'a, T> MutSwitch<'a, T, CTFalse> {
+    /// Constructs this enum with an immutable reference.
+    pub fn from_ref(t: &'a T) -> Self {
+        MutSwitch::VarImut(t)
+    }
+
+    /// Returns the stored reference.
+    pub fn get(&self) -> &T {
+        match *self {
+            MutSwitch::VarImut(ref t) => t,
+            _ => unreachable!(),
+        }
+    }
+}
+
+// Implement mutable functionality.
+impl<'a, T> MutSwitch<'a, T, CTTrue> {
+    /// Constructs this enum with a mutable reference.
+    pub fn from_mut(t: &'a mut T) -> Self {
+        MutSwitch::VarMut(t, CTTrue)
+    }
+
+    /// Returns the mutable reference stored within.
+    pub fn get(&mut self) -> &mut T {
+        match *self {
+            MutSwitch::VarMut(ref mut v, _) => v,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<'a, T> AsRef<T> for MutSwitch<'a, T, CTFalse> {
+    fn as_ref(&self) -> &T {
+        self.get()
+    }
+}
+
+impl<'a, T> AsMut<T> for MutSwitch<'a, T, CTTrue> {
+    fn as_mut(&mut self) -> &mut T {
+        self.get()
+    }
+}
+
+impl<'a, T> From<&'a T> for MutSwitch<'a, T, CTFalse> {
+    fn from(t: &'a T) -> Self {
+        MutSwitch::from_ref(t)
+    }
+}
+
+impl<'a, T> From<&'a mut T> for MutSwitch<'a, T, CTTrue> {
+    fn from(t: &'a mut T) -> Self {
+        MutSwitch::from_mut(t)
+    }
+}

--- a/medici_core/src/error.rs
+++ b/medici_core/src/error.rs
@@ -180,6 +180,17 @@ pub mod custom_type {
         }
     }
 
+    /// Enumeration of publicl cases of state machine failures.
+    #[derive(Debug, Fail, Clone, Eq, PartialEq)]
+    pub enum ZoneMoveError {
+        /// Error indicating that the entity was not found in a zone.
+        #[fail(display = "The entity was not found within the provided zone")]
+        NotInZone,
+        /// Error indicating that the targetted zone is already at maximum capacity.
+        #[fail(display = "The targetted zone is full")]
+        ZoneFull,
+    }
+
     /// Code failed to push a new item onto the chosen stack.
     #[derive(Debug, Fail)]
     #[fail(display = "Error unpacking the provided transaction")]

--- a/medici_core/src/function.rs
+++ b/medici_core/src/function.rs
@@ -110,15 +110,27 @@ pub trait CardBuilder<C: Card> {
 }
 
 /// Types that construct an [`Adapter`] for a specific [`Service`].
-pub trait AdapterCompliant<A>
+// Note: This trait holds an explicit lifetime because we're working with lifetimes
+// that live longer than the scoped borrow of self!
+// &'a self == the reference to self lives at least as long as a, if no lifetime
+// is explicitly stated the compiler inserts one automatically which is only valid 
+// for the function body. This leads to uncertainty about 'unk, which should be valid
+// for 'unkn: 'a -> unkn lives at least as long as a.
+pub trait AdapterCompliant<'a, A>
 where
-    A: marker::Adapter,
+    A: marker::Adapter + 'a,
 {
     /// Creates an adapter around the provided service.
-    fn build(&self, service: &A::Adapting) -> A;
+    fn build(&'a self, service: &'a A::Adapting) -> A;
+}
 
+/// Types that construct an [`Adapter`] for a specific [`Service`].
+pub trait AdapterCompliantMut<'a, A>
+where
+    A: marker::Adapter + 'a,
+{
     /// Creates an adapter around the provided service.
-    fn build_mut(&mut self, service: &mut A::Adapting) -> A;
+    fn build_mut(&'a mut self, service: &'a mut A::Adapting) -> A;
 }
 
 /// Trait for implementing a certain service on the state machine.

--- a/medici_core/src/function.rs
+++ b/medici_core/src/function.rs
@@ -109,13 +109,24 @@ pub trait CardBuilder<C: Card> {
     fn new_with_id<I: Into<C::ID>>(id: I) -> C;
 }
 
-/// Types that construct an [`Adapter`] for a specific [`Service`].
-// Note: This trait holds an explicit lifetime because we're working with lifetimes
-// that live longer than the scoped borrow of self!
-// &'a self == the reference to self lives at least as long as a, if no lifetime
-// is explicitly stated the compiler inserts one automatically which is only valid 
-// for the function body. This leads to uncertainty about 'unk, which should be valid
-// for 'unkn: 'a -> unkn lives at least as long as a.
+/// Types that construct an [`Adapter`] around some [`Service`].
+/// 
+/// The adapter is built from service stubs, which own additional data, and the 
+/// selected service. The adapter often contains nothing more than borrows of 
+/// services and/or storage objects.
+/// 
+/// # See also
+/// [`marker::Adapter`]
+/// 
+// Note: This trait holds an explicit lifetime because all borrows that go into the
+// adapter must outlive that adapter (A: 'a).
+// &'a self == self outlives lifetime a.  OR
+// the reference to self is valid up to lifetime a.
+// When no lifetime is specified (lifetime ellision), the compiler will insert a new
+// one for us automatically. For example lifetime "unknown".
+// 'unknown is always strictly shorter than 'a because of scoping. The compiler cannot 
+// constraint make 'unknown == 'a if no constraints are provided 
+// ('unknown: 'a == lifetime unknown lives at least as long as lifetime a)
 pub trait AdapterCompliant<'a, A>
 where
     A: marker::Adapter + 'a,
@@ -124,7 +135,10 @@ where
     fn build(&'a self, service: &'a A::Adapting) -> A;
 }
 
-/// Types that construct an [`Adapter`] for a specific [`Service`].
+/// Types that construct an [`Adapter`] around some [`Service`].
+/// 
+/// # See also
+/// [`AdapterCompliant`]
 pub trait AdapterCompliantMut<'a, A>
 where
     A: marker::Adapter + 'a,

--- a/medici_core/src/function.rs
+++ b/medici_core/src/function.rs
@@ -109,6 +109,18 @@ pub trait CardBuilder<C: Card> {
     fn new_with_id<I: Into<C::ID>>(id: I) -> C;
 }
 
+/// Types that construct an [`Adapter`] for a specific [`Service`].
+pub trait AdapterCompliant<A>
+where
+    A: marker::Adapter,
+{
+    /// Creates an adapter around the provided service.
+    fn build(&self, service: &A::Adapting) -> A;
+
+    /// Creates an adapter around the provided service.
+    fn build_mut(&mut self, service: &mut A::Adapting) -> A;
+}
+
 /// Trait for implementing a certain service on the state machine.
 ///
 /// Because of this design exactly one object of each service type can be hooked onto
@@ -162,6 +174,12 @@ pub trait ArrayStorageCompliance {
 
     /// Returns the current storage as a slice, which is an indexed storage.
     fn as_slice_mut(&mut self) -> &mut [Self::Item];
+}
+
+/// Types which enumerate all entity zones in the game.
+pub trait ZoneEnumerator {
+    /// Returns the amount of entities this zone can hold.
+    fn max_entities(&self) -> usize;
 }
 
 /* ID sructures */

--- a/medici_core/src/function.rs
+++ b/medici_core/src/function.rs
@@ -110,22 +110,22 @@ pub trait CardBuilder<C: Card> {
 }
 
 /// Types that construct an [`Adapter`] around some [`Service`].
-/// 
-/// The adapter is built from service stubs, which own additional data, and the 
-/// selected service. The adapter often contains nothing more than borrows of 
+///
+/// The adapter is built from service stubs, which own additional data, and the
+/// selected service. The adapter often contains nothing more than borrows of
 /// services and/or storage objects.
-/// 
+///
 /// # See also
 /// [`marker::Adapter`]
-/// 
+///
 // Note: This trait holds an explicit lifetime because all borrows that go into the
 // adapter must outlive that adapter (A: 'a).
 // &'a self == self outlives lifetime a.  OR
 // the reference to self is valid up to lifetime a.
 // When no lifetime is specified (lifetime ellision), the compiler will insert a new
 // one for us automatically. For example lifetime "unknown".
-// 'unknown is always strictly shorter than 'a because of scoping. The compiler cannot 
-// constraint make 'unknown == 'a if no constraints are provided 
+// 'unknown is always strictly shorter than 'a because of scoping. The compiler cannot
+// constraint make 'unknown == 'a if no constraints are provided
 // ('unknown: 'a == lifetime unknown lives at least as long as lifetime a)
 pub trait AdapterCompliant<'a, A>
 where
@@ -136,7 +136,7 @@ where
 }
 
 /// Types that construct an [`Adapter`] around some [`Service`].
-/// 
+///
 /// # See also
 /// [`AdapterCompliant`]
 pub trait AdapterCompliantMut<'a, A>

--- a/medici_core/src/lib.rs
+++ b/medici_core/src/lib.rs
@@ -41,6 +41,7 @@ pub mod prefab;
 pub mod ctstack;
 #[macro_use]
 pub mod macros;
+pub mod ctmut;
 
 pub mod error;
 pub mod function;

--- a/medici_core/src/marker.rs
+++ b/medici_core/src/marker.rs
@@ -17,6 +17,15 @@ pub trait TransactionContainer {}
 /// way to quickly de-/construct state machines with various functional methods.
 pub trait Service {}
 
+/// Types that wrap a service.
+///
+/// Adapters provide aditional functionality making use of the wrapped service.
+/// Adapters are transitively also a [`Service`]!
+pub trait Adapter: Service {
+    /// The type that's being augmented.
+    type Adapting;
+}
+
 /// Types which enumerate all known [`Prototype`]s.
 pub trait ProtoEnumerator {}
 

--- a/medici_core/src/marker.rs
+++ b/medici_core/src/marker.rs
@@ -20,7 +20,7 @@ pub trait Service {}
 /// Types that wrap a service.
 ///
 /// Adapters provide aditional functionality making use of the wrapped service.
-/// 
+///
 /// # Note
 /// Adapters are transitively also a [`Service`]!
 pub trait Adapter: Service {

--- a/medici_core/src/marker.rs
+++ b/medici_core/src/marker.rs
@@ -20,6 +20,8 @@ pub trait Service {}
 /// Types that wrap a service.
 ///
 /// Adapters provide aditional functionality making use of the wrapped service.
+/// 
+/// # Note
 /// Adapters are transitively also a [`Service`]!
 pub trait Adapter: Service {
     /// The type that's being augmented.

--- a/medici_core/src/service/entity.rs
+++ b/medici_core/src/service/entity.rs
@@ -3,7 +3,7 @@
 use std::fmt::{Debug, Display};
 
 use error::custom_type::{MissingEntityError, OverflowError};
-use function::{ArrayStorageCompliance, Entity, EntityBuilder};
+use function::{ArrayStorageCompliance, Entity, EntityBuilder, Identifiable, EntityId};
 use marker;
 use storage::EntityStorage;
 
@@ -11,8 +11,7 @@ use storage::EntityStorage;
 /// Structure for working with [`Entity`] objects.
 pub struct EntityService<E>
 where
-    E: Entity + EntityBuilder<E> + Clone,
-    E::ID: Into<usize> + From<usize> + Debug + Display,
+    E: Entity + Identifiable<ID = EntityId> + Clone,
 {
     storage: EntityStorage<E>,
     maximum_items: usize,
@@ -20,15 +19,13 @@ where
 
 impl<E> marker::Service for EntityService<E>
 where
-    E: Entity + EntityBuilder<E> + Clone,
-    E::ID: Into<usize> + From<usize> + Debug + Display,
+    E: Entity + Identifiable<ID = EntityId> + Clone,
 {
 }
 
 impl<E> EntityService<E>
 where
-    E: Entity + EntityBuilder<E> + Clone,
-    E::ID: Into<usize> + From<usize> + Debug + Display,
+    E: Entity + Identifiable<ID = EntityId> + EntityBuilder<E> + Clone,
 {
     /// Creates a new object for storage.
     pub fn new<M: Into<usize>>(maximum_items: M) -> Self {
@@ -55,19 +52,17 @@ where
 
     /// Retrieves a reference to the entity matching the id.
     pub fn get(&self, id: E::ID) -> Result<&E, MissingEntityError<E::ID>> {
-        let idx_id = id.into();
         self.storage
             .as_slice()
-            .get(idx_id)
+            .get(id)
             .ok_or(MissingEntityError(id))
     }
 
     /// Retrieves a mutable reference to the entity matching the id.
     pub fn get_mut(&mut self, id: E::ID) -> Result<&mut E, MissingEntityError<E::ID>> {
-        let idx_id = id.into();
         self.storage
             .as_slice_mut()
-            .get_mut(idx_id)
+            .get_mut(id)
             .ok_or(MissingEntityError(id))
     }
 }

--- a/medici_core/src/service/entity.rs
+++ b/medici_core/src/service/entity.rs
@@ -3,7 +3,7 @@
 use std::fmt::{Debug, Display};
 
 use error::custom_type::{MissingEntityError, OverflowError};
-use function::{ArrayStorageCompliance, Entity, EntityBuilder, Identifiable, EntityId};
+use function::{ArrayStorageCompliance, Entity, EntityBuilder, EntityId, Identifiable};
 use marker;
 use storage::EntityStorage;
 

--- a/medici_core/src/service/mod.rs
+++ b/medici_core/src/service/mod.rs
@@ -7,6 +7,7 @@
 pub mod card;
 pub mod entity;
 pub mod trigger;
+pub mod zone;
 
 pub use self::card::CardService;
 pub use self::entity::EntityService;

--- a/medici_core/src/service/zone.rs
+++ b/medici_core/src/service/zone.rs
@@ -2,42 +2,85 @@
 
 use std::hash::Hash;
 
-use ctmut::{CTBool, MutSwitch};
-use function::{Entity, EntityId, Identifiable, ZoneEnumerator};
+use ctmut::{CTBool, MutSwitch, CTTrue, CTFalse};
+use function::{Entity, EntityId, Identifiable, ZoneEnumerator, AdapterCompliant};
 use marker;
-use storage::{EntityStorage, ZoneStorage};
+use storage::ZoneStorage;
+use service::EntityService;
 
+#[derive(Debug)]
 /// Structure that allows for manipulating zone data. This behaviour
 /// is provided by abstracting over the entity storage structure.
-pub struct ZoneAdapter<'a, 'b, AllowMut, E, ZE>
+// Note: Only one lifetime parameter is used because we are only interested
+// in exactly one constraint: Fields (and containing references) outlive
+// the adapter struct (lifetime a). The adapter does NOT outlive 'a, so 
+// all containing references are valid up to 'a. The constraint itself is
+// formulated as [lifetime of entities]: 'a, the [lifetime of entities]
+// is at least as long as the lifetime a.
+pub struct ZoneAdapter<'a, AllowMut, E, ZE>
 where
     AllowMut: CTBool,
     E: Entity + Identifiable<ID = EntityId> + Clone,
     ZE: ZoneEnumerator + Hash + Eq + Default,
-    EntityStorage<E>: 'a,
-    ZoneStorage<E, ZE>: 'b,
+    EntityService<E>: 'a,
+    ZoneStorage<E, ZE>: 'a,
 {
-    entities: MutSwitch<'a, EntityStorage<E>, AllowMut>,
-    zones: MutSwitch<'b, ZoneStorage<E, ZE>, AllowMut>,
+    entities: MutSwitch<'a, EntityService<E>, AllowMut>,
+    zones: MutSwitch<'a, ZoneStorage<E, ZE>, AllowMut>,
 }
 
-impl<'a, 'b, AllowMut, E, ZE> marker::Service for ZoneAdapter<'a, 'b, AllowMut, E, ZE>
-where
-    AllowMut: CTBool,
-    E: Entity + Identifiable<ID = EntityId> + Clone,
-    ZE: ZoneEnumerator + Hash + Eq + Default,
-{
-}
-
-impl<'a, 'b, AllowMut, E, ZE> marker::Adapter for ZoneAdapter<'a, 'b, AllowMut, E, ZE>
+impl<'a, AllowMut, E, ZE> marker::Service for ZoneAdapter<'a, AllowMut, E, ZE>
 where
     AllowMut: CTBool,
     E: Entity + Identifiable<ID = EntityId> + Clone,
     ZE: ZoneEnumerator + Hash + Eq + Default,
 {
-    type Adapting = EntityStorage<E>;
 }
 
-// struct ZoneService {
-// 	storage: ZoneStorage,
-// }
+impl<'a, AllowMut, E, ZE> marker::Adapter for ZoneAdapter<'a, AllowMut, E, ZE>
+where
+    AllowMut: CTBool,
+    E: Entity + Identifiable<ID = EntityId> + Clone,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+{
+    type Adapting = EntityService<E>;
+}
+
+#[derive(Debug)]
+/// Structure for creating an [`Adapter`] that allows manipulation of zone information.
+/// 
+/// Do not use this stub directly! The purpose of this stub is to own the zone information.
+/// Create an [`Adapter`] from this type and [`EntityService`] to manipulate zone information!
+pub struct ZoneServiceStub<E, ZE> 
+where
+    E: Entity + Identifiable<ID = EntityId> + Clone,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+{
+    storage: ZoneStorage<E, ZE>,
+}
+
+impl<E, ZE> ZoneServiceStub<E, ZE> 
+where
+    E: Entity + Identifiable<ID = EntityId> + Clone,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+{
+    /// Constructs a new service stub which owns the zone information data.
+    pub fn new() -> Self {
+        Self {
+            storage: ZoneStorage::new(),
+        }
+    }
+}
+
+impl<'a, E, ZE> AdapterCompliant<'a, ZoneAdapter<'a, CTFalse, E, ZE>> for ZoneServiceStub<E, ZE> 
+where
+    E: Entity + Identifiable<ID = EntityId> + Clone,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+{
+    fn build(&'a self, service: &'a EntityService<E>) -> ZoneAdapter<CTFalse, E, ZE> {
+        ZoneAdapter {
+            entities: MutSwitch::from_ref(service),
+            zones: MutSwitch::from_ref(&self.storage),
+        }
+    }
+}

--- a/medici_core/src/service/zone.rs
+++ b/medici_core/src/service/zone.rs
@@ -34,6 +34,10 @@ where
     E: Entity + Identifiable<ID = EntityId> + Clone,
     ZE: ZoneEnumerator + Hash + Eq + Default,
 {
+    /// Returns an iterator over all entities within the provided zone.
+    pub fn iter_zone(&self, zone: ZE) -> impl Iterator<Item=&E> {
+        self.zones.get().zone_assignment.get(&zone).unwrap_or(&vec![]).iter()
+    }
 }
 
 impl<'a, E, ZE> ZoneAdapter<'a, CTTrue, E, ZE> 
@@ -41,6 +45,10 @@ where
     E: Entity + Identifiable<ID = EntityId> + Clone,
     ZE: ZoneEnumerator + Hash + Eq + Default,
 {
+    /// Returns an iterator over all entities within the provided zone.
+    pub fn iter_zone(&mut self, zone: ZE) -> impl Iterator<Item=&mut E> {
+        self.zones.get().zone_assignment.get_mut(&zone).unwrap_or(&mut vec![]).iter()
+    }
 }
 
 impl<'a, AllowMut, E, ZE> marker::Service for ZoneAdapter<'a, AllowMut, E, ZE>

--- a/medici_core/src/service/zone.rs
+++ b/medici_core/src/service/zone.rs
@@ -3,7 +3,7 @@
 use std::hash::Hash;
 
 use ctmut::{CTBool, MutSwitch, CTTrue, CTFalse};
-use function::{Entity, EntityId, Identifiable, ZoneEnumerator, AdapterCompliant};
+use function::{Entity, EntityId, Identifiable, ZoneEnumerator, AdapterCompliant, AdapterCompliantMut};
 use marker;
 use storage::ZoneStorage;
 use service::EntityService;
@@ -27,6 +27,20 @@ where
 {
     entities: MutSwitch<'a, EntityService<E>, AllowMut>,
     zones: MutSwitch<'a, ZoneStorage<E, ZE>, AllowMut>,
+}
+
+impl<'a, E, ZE> ZoneAdapter<'a, CTFalse, E, ZE> 
+where
+    E: Entity + Identifiable<ID = EntityId> + Clone,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+{
+}
+
+impl<'a, E, ZE> ZoneAdapter<'a, CTTrue, E, ZE> 
+where
+    E: Entity + Identifiable<ID = EntityId> + Clone,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+{
 }
 
 impl<'a, AllowMut, E, ZE> marker::Service for ZoneAdapter<'a, AllowMut, E, ZE>
@@ -81,6 +95,19 @@ where
         ZoneAdapter {
             entities: MutSwitch::from_ref(service),
             zones: MutSwitch::from_ref(&self.storage),
+        }
+    }
+}
+
+impl<'a, E, ZE> AdapterCompliantMut<'a, ZoneAdapter<'a, CTTrue, E, ZE>> for ZoneServiceStub<E, ZE> 
+where
+    E: Entity + Identifiable<ID = EntityId> + Clone,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+{
+    fn build_mut(&'a mut self, service: &'a mut EntityService<E>) -> ZoneAdapter<CTTrue, E, ZE> {
+        ZoneAdapter {
+            entities: MutSwitch::from_mut(service),
+            zones: MutSwitch::from_mut(&mut self.storage),
         }
     }
 }

--- a/medici_core/src/service/zone.rs
+++ b/medici_core/src/service/zone.rs
@@ -1,0 +1,43 @@
+//! Module containing zone related structs.
+
+use std::hash::Hash;
+
+use ctmut::{CTBool, MutSwitch};
+use function::{Entity, EntityId, Identifiable, ZoneEnumerator};
+use marker;
+use storage::{EntityStorage, ZoneStorage};
+
+/// Structure that allows for manipulating zone data. This behaviour
+/// is provided by abstracting over the entity storage structure.
+pub struct ZoneAdapter<'a, 'b, AllowMut, E, ZE>
+where
+    AllowMut: CTBool,
+    E: Entity + Identifiable<ID = EntityId> + Clone,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+    EntityStorage<E>: 'a,
+    ZoneStorage<E, ZE>: 'b,
+{
+    entities: MutSwitch<'a, EntityStorage<E>, AllowMut>,
+    zones: MutSwitch<'b, ZoneStorage<E, ZE>, AllowMut>,
+}
+
+impl<'a, 'b, AllowMut, E, ZE> marker::Service for ZoneAdapter<'a, 'b, AllowMut, E, ZE>
+where
+    AllowMut: CTBool,
+    E: Entity + Identifiable<ID = EntityId> + Clone,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+{
+}
+
+impl<'a, 'b, AllowMut, E, ZE> marker::Adapter for ZoneAdapter<'a, 'b, AllowMut, E, ZE>
+where
+    AllowMut: CTBool,
+    E: Entity + Identifiable<ID = EntityId> + Clone,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+{
+    type Adapting = EntityStorage<E>;
+}
+
+// struct ZoneService {
+// 	storage: ZoneStorage,
+// }

--- a/medici_core/src/service/zone.rs
+++ b/medici_core/src/service/zone.rs
@@ -2,18 +2,21 @@
 
 use std::hash::Hash;
 
-use ctmut::{CTBool, MutSwitch, CTTrue, CTFalse};
-use function::{Entity, EntityId, Identifiable, ZoneEnumerator, AdapterCompliant, AdapterCompliantMut};
+use ctmut::{CTBool, CTFalse, CTTrue, MutSwitch};
+use function::{
+    AdapterCompliant, AdapterCompliantMut, Entity, EntityBuilder, EntityId, Identifiable,
+    ZoneEnumerator,
+};
 use marker;
-use storage::ZoneStorage;
 use service::EntityService;
+use storage::ZoneStorage;
 
 #[derive(Debug)]
 /// Structure that allows for manipulating zone data. This behaviour
 /// is provided by abstracting over the entity storage structure.
 // Note: Only one lifetime parameter is used because we are only interested
 // in exactly one constraint: Fields (and containing references) outlive
-// the adapter struct (lifetime a). The adapter does NOT outlive 'a, so 
+// the adapter struct (lifetime a). The adapter does NOT outlive 'a, so
 // all containing references are valid up to 'a. The constraint itself is
 // formulated as [lifetime of entities]: 'a, the [lifetime of entities]
 // is at least as long as the lifetime a.
@@ -25,29 +28,43 @@ where
     EntityService<E>: 'a,
     ZoneStorage<E, ZE>: 'a,
 {
-    entities: MutSwitch<'a, EntityService<E>, AllowMut>,
-    zones: MutSwitch<'a, ZoneStorage<E, ZE>, AllowMut>,
+    entity_wrapper: MutSwitch<'a, EntityService<E>, AllowMut>,
+    zone_wrapper: MutSwitch<'a, ZoneStorage<E, ZE>, AllowMut>,
 }
 
-impl<'a, E, ZE> ZoneAdapter<'a, CTFalse, E, ZE> 
+impl<'a, E, ZE> ZoneAdapter<'a, CTFalse, E, ZE>
 where
-    E: Entity + Identifiable<ID = EntityId> + Clone,
+    E: Entity + Identifiable<ID = EntityId> + EntityBuilder<E> + Clone,
+    EntityId: Clone,
     ZE: ZoneEnumerator + Hash + Eq + Default,
 {
     /// Returns an iterator over all entities within the provided zone.
-    pub fn iter_zone(&self, zone: ZE) -> impl Iterator<Item=&E> {
-        self.zones.get().zone_assignment.get(&zone).unwrap_or(&vec![]).iter()
+    pub fn iter_zone(&self, zone: ZE) -> impl Iterator<Item = &E> {
+        let entity_service = self.entity_wrapper.get();
+        let zone_storage = self.zone_wrapper.get();
+        zone_storage
+            .zone_assignment
+            .get(&zone)
+            .map_or_else(|| [].iter(), |z| z.iter())
+            .map(move |e_id| entity_service.get(*e_id).unwrap())
     }
 }
 
-impl<'a, E, ZE> ZoneAdapter<'a, CTTrue, E, ZE> 
+impl<'a, E, ZE> ZoneAdapter<'a, CTTrue, E, ZE>
 where
-    E: Entity + Identifiable<ID = EntityId> + Clone,
+    E: Entity + Identifiable<ID = EntityId> + EntityBuilder<E> + Clone,
+    EntityId: Clone,
     ZE: ZoneEnumerator + Hash + Eq + Default,
 {
     /// Returns an iterator over all entities within the provided zone.
-    pub fn iter_zone(&mut self, zone: ZE) -> impl Iterator<Item=&mut E> {
-        self.zones.get().zone_assignment.get_mut(&zone).unwrap_or(&mut vec![]).iter()
+    pub fn iter_zone(&mut self, zone: ZE) -> impl Iterator<Item = &mut E> {
+        let entity_service = self.entity_wrapper.get_mut();
+        let zone_storage = self.zone_wrapper.get_mut();
+        zone_storage
+            .zone_assignment
+            .get_mut(&zone)
+            .map_or_else(|| [].iter_mut(), |z| z.iter_mut())
+            .map(move |e_id| entity_service.get_mut(*e_id).unwrap())
     }
 }
 
@@ -70,10 +87,10 @@ where
 
 #[derive(Debug)]
 /// Structure for creating an [`Adapter`] that allows manipulation of zone information.
-/// 
+///
 /// Do not use this stub directly! The purpose of this stub is to own the zone information.
 /// Create an [`Adapter`] from this type and [`EntityService`] to manipulate zone information!
-pub struct ZoneServiceStub<E, ZE> 
+pub struct ZoneServiceStub<E, ZE>
 where
     E: Entity + Identifiable<ID = EntityId> + Clone,
     ZE: ZoneEnumerator + Hash + Eq + Default,
@@ -81,7 +98,7 @@ where
     storage: ZoneStorage<E, ZE>,
 }
 
-impl<E, ZE> ZoneServiceStub<E, ZE> 
+impl<E, ZE> ZoneServiceStub<E, ZE>
 where
     E: Entity + Identifiable<ID = EntityId> + Clone,
     ZE: ZoneEnumerator + Hash + Eq + Default,
@@ -94,28 +111,28 @@ where
     }
 }
 
-impl<'a, E, ZE> AdapterCompliant<'a, ZoneAdapter<'a, CTFalse, E, ZE>> for ZoneServiceStub<E, ZE> 
+impl<'a, E, ZE> AdapterCompliant<'a, ZoneAdapter<'a, CTFalse, E, ZE>> for ZoneServiceStub<E, ZE>
 where
     E: Entity + Identifiable<ID = EntityId> + Clone,
     ZE: ZoneEnumerator + Hash + Eq + Default,
 {
     fn build(&'a self, service: &'a EntityService<E>) -> ZoneAdapter<CTFalse, E, ZE> {
         ZoneAdapter {
-            entities: MutSwitch::from_ref(service),
-            zones: MutSwitch::from_ref(&self.storage),
+            entity_wrapper: MutSwitch::from_ref(service),
+            zone_wrapper: MutSwitch::from_ref(&self.storage),
         }
     }
 }
 
-impl<'a, E, ZE> AdapterCompliantMut<'a, ZoneAdapter<'a, CTTrue, E, ZE>> for ZoneServiceStub<E, ZE> 
+impl<'a, E, ZE> AdapterCompliantMut<'a, ZoneAdapter<'a, CTTrue, E, ZE>> for ZoneServiceStub<E, ZE>
 where
     E: Entity + Identifiable<ID = EntityId> + Clone,
     ZE: ZoneEnumerator + Hash + Eq + Default,
 {
     fn build_mut(&'a mut self, service: &'a mut EntityService<E>) -> ZoneAdapter<CTTrue, E, ZE> {
         ZoneAdapter {
-            entities: MutSwitch::from_mut(service),
-            zones: MutSwitch::from_mut(&mut self.storage),
+            entity_wrapper: MutSwitch::from_mut(service),
+            zone_wrapper: MutSwitch::from_mut(&mut self.storage),
         }
     }
 }

--- a/medici_core/src/storage/mod.rs
+++ b/medici_core/src/storage/mod.rs
@@ -4,8 +4,10 @@ pub mod card;
 pub mod entity;
 pub mod transaction;
 pub mod trigger;
+pub mod zone;
 
 pub use self::card::CardStorage;
 pub use self::entity::EntityStorage;
 pub use self::transaction::TransactionStorage;
 pub use self::trigger::TriggerStorage;
+pub use self::zone::ZoneStorage;

--- a/medici_core/src/storage/zone.rs
+++ b/medici_core/src/storage/zone.rs
@@ -1,0 +1,39 @@
+//! Module containing structures for storing zone information.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use error::custom_type::ZoneMoveError;
+use function::{Entity, ZoneEnumerator};
+
+#[derive(Debug)]
+/// Structure containing the zone assignment for each [`Entity`].
+pub struct ZoneStorage<E, ZE>
+where
+    E: Entity,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+{
+    /// Hashmap containing a sorted list of entities for each zone.
+    /// The position of each entity within that list represents the position
+    /// within that zone.
+    pub zone_assignment: HashMap<ZE, Vec<E::ID>>,
+}
+
+impl<E, ZE> ZoneStorage<E, ZE>
+where
+    E: Entity,
+    ZE: ZoneEnumerator + Hash + Eq + Default,
+{
+    /// Creates a new storage object which keeps track of entities
+    /// and their zone assignment.
+    pub fn new() -> Self {
+        Self {
+            zone_assignment: hashmap!{},
+        }
+    }
+
+    /// Moves the provided [`Entity`] from its current zone into the targetted zone.
+    pub fn zone_move(&mut self, entity: &mut E, from: ZE, to: ZE) -> Result<(), ZoneMoveError> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
EntityService contains only EntityStruct data. The requirement is that this (and other) services are extensible to allow for more data to be collected and manipulated against Entities (and other game objects).
This is a problem because the services need to be extensible in an open-ended way, no (or very few) assumptions can be made. It's not feasible to delegate that responsibility itself onto the EntityService, so another approach must be selected.
Another issue is that this open-endedness causes issues with owning the data. Whatever additional data you keep must be stored and owned somewhere which again cannot be the responsibility of EntityService.

A solution which is being worked on at the moment uses the concept of adapters, similar to all the iterator structures in the standard library. The point of adapters is providing additional functionality by compositing existing/other services into a new Adapter structure. 
To construct these adapters another new type is introduced called ServiceStubs. These types own the data to specifically support the extensibility purpose. The adapter itself is merely a container of references to the stub-owned data and the wrapped service. The required functionality is then implemented on the adapter type.
It's also possible to create adapters from adapters, but no example has been constructed yet.